### PR TITLE
Enhancement: Use `ergebnis/.github` to determine the composer root version

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -8,9 +8,6 @@ on: # yamllint disable-line rule:truthy
     branches:
       - "main"
 
-env:
-  COMPOSER_ROOT_VERSION: "3.4-dev"
-
 jobs:
   code-coverage:
     name: "Code Coverage"
@@ -46,6 +43,9 @@ jobs:
 
       - name: "Validate composer.json and composer.lock"
         run: "composer validate --ansi --strict"
+
+      - name: "Determine composer root version"
+        uses: "ergebnis/.github/actions/composer/determine-root-version@1.9.2"
 
       - name: "Determine composer cache directory"
         uses: "ergebnis/.github/actions/composer/determine-cache-directory@1.9.2"
@@ -112,6 +112,9 @@ jobs:
 
       - name: "Validate composer.json and composer.lock"
         run: "composer validate --ansi --strict"
+
+      - name: "Determine composer root version"
+        uses: "ergebnis/.github/actions/composer/determine-root-version@1.9.2"
 
       - name: "Determine composer cache directory"
         uses: "ergebnis/.github/actions/composer/determine-cache-directory@1.9.2"
@@ -181,6 +184,9 @@ jobs:
       - name: "Validate composer.json and composer.lock"
         run: "composer validate --ansi --strict"
 
+      - name: "Determine composer root version"
+        uses: "ergebnis/.github/actions/composer/determine-root-version@1.9.2"
+
       - name: "Determine composer cache directory"
         uses: "ergebnis/.github/actions/composer/determine-cache-directory@1.9.2"
 
@@ -236,6 +242,9 @@ jobs:
       - name: "Validate composer.json and composer.lock"
         run: "composer validate --ansi --strict"
 
+      - name: "Determine composer root version"
+        uses: "ergebnis/.github/actions/composer/determine-root-version@1.9.2"
+
       - name: "Determine composer cache directory"
         uses: "ergebnis/.github/actions/composer/determine-cache-directory@1.9.2"
 
@@ -287,6 +296,9 @@ jobs:
 
       - name: "Validate composer.json and composer.lock"
         run: "composer validate --ansi --strict"
+
+      - name: "Determine composer root version"
+        uses: "ergebnis/.github/actions/composer/determine-root-version@1.9.2"
 
       - name: "Determine composer cache directory"
         uses: "ergebnis/.github/actions/composer/determine-cache-directory@1.9.2"
@@ -347,6 +359,9 @@ jobs:
       - name: "Validate composer.json and composer.lock"
         run: "composer validate --ansi --strict"
 
+      - name: "Determine composer root version"
+        uses: "ergebnis/.github/actions/composer/determine-root-version@1.9.2"
+
       - name: "Determine composer cache directory"
         uses: "ergebnis/.github/actions/composer/determine-cache-directory@1.9.2"
 
@@ -396,6 +411,9 @@ jobs:
 
       - name: "Validate composer.json and composer.lock"
         run: "composer validate --ansi --strict"
+
+      - name: "Determine composer root version"
+        uses: "ergebnis/.github/actions/composer/determine-root-version@1.9.2"
 
       - name: "Determine composer cache directory"
         uses: "ergebnis/.github/actions/composer/determine-cache-directory@1.9.2"
@@ -456,6 +474,9 @@ jobs:
 
       - name: "Validate composer.json and composer.lock"
         run: "composer validate --ansi --strict"
+
+      - name: "Determine composer root version"
+        uses: "ergebnis/.github/actions/composer/determine-root-version@1.9.2"
 
       - name: "Determine composer cache directory"
         uses: "ergebnis/.github/actions/composer/determine-cache-directory@1.9.2"

--- a/.github/workflows/renew.yaml
+++ b/.github/workflows/renew.yaml
@@ -6,9 +6,6 @@ on: # yamllint disable-line rule:truthy
   schedule:
     - cron: "0 0 1 1 *"
 
-env:
-  COMPOSER_ROOT_VERSION: "3.4-dev"
-
 jobs:
   license:
     name: "License"
@@ -43,6 +40,9 @@ jobs:
 
       - name: "Validate composer.json and composer.lock"
         run: "composer validate --ansi --strict"
+
+      - name: "Determine composer root version"
+        uses: "ergebnis/.github/actions/composer/determine-root-version@1.9.2"
 
       - name: "Determine composer cache directory"
         uses: "ergebnis/.github/actions/composer/determine-cache-directory@1.9.2"


### PR DESCRIPTION
This pull request

- [x] uses `ergebnis/.github` to determine the composer root version